### PR TITLE
Fix clang-format install in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,9 @@ jobs:
         with:
           python-version: 3.8
       - name: Install clang-format
-        run: sudo apt-get install clang-format-10
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install clang-format-10
       - name: Install wpiformat
         run: pip3 install wpiformat
       - name: Run


### PR DESCRIPTION
The apt repo had a version bump, so newer versions of the package
databases need to be downloaded.